### PR TITLE
Smaller updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,9 @@ Want to contribute to the list? Read the [contributors guide](CONTRIBUTING.md)!
 
 ### Community
 
-* [Forums](https://bitsharestalk.org) - The origins of BitShares since 2013
+* [Forums](https://bitsharestalk.org) - The original board of discussion for BitShares (ever since 2013)
 * [Steem#bitshares](https://steemit.com/trending/bitshares) - #bitshares tagged posts on the STEEM blockchain
+* [Whaleshares#bitshares](https://whaleshares.io/trending/bitshares) - #bitshares tagged posts on the WHALESHARES blockchain
 * [Twitter#bitshares](https://twitter.com/search?q=%23bitshares) - #bitshares tagged on Twitter
 * [Reddit#bitshares](https://reddit.com/r/bitshares) - Reddit sub
 * Telegram:
@@ -79,8 +80,9 @@ Want to contribute to the list? Read the [contributors guide](CONTRIBUTING.md)!
 
 ### Conferences
 
-* [Bitfest 2018](https://steemit.com/@bitfest) - in Amsterdam
-* [Graphene DevCon 2018](https://steemit.com/graphene/@jademont/global-graphene-blockchain-devcon-is-successfully-concluded) - in Shanghai
+* [Bitfest 2018](https://steemit.com/@bitfest) - in Amsterdam, Netherlands
+* [Decentralized 2018 - BitShares as Platinum Sponsor](https://www.decentralized.com/blog/2018/12/02/decentralized-2018-day-1-annemieke-dirkes-bitshares/) - In Athens, Greece
+* [Graphene DevCon 2018](https://steemit.com/graphene/@jademont/global-graphene-blockchain-devcon-is-successfully-concluded) - in Shanghai, China
 
 ## Utilities
 
@@ -97,8 +99,8 @@ wallet.bitshares.org.
 
 * [BTS++](http://btspp.io/) - native Android/iOS app
 * [Beet](https://github.com/bitshares/beet/) - standalone web application
-* [Reference Wallet](https://github.com/bitshares/bitshares-ui) - reference web wallet
-* [Trusty/Community UI](https://github.com/bitshares/bitshares-community-ui) - android app built on VueJS
+* [Reference Wallet](https://github.com/bitshares/bitshares-ui) - reference web wallet (ReactJS)
+* [Community UI](https://github.com/bitshares/bitshares-community-ui) - fully responsive community web wallet (VueJS)
 * [Uptick](http://uptick.rocks) - command line tool
 
 ### Hosted Wallets
@@ -134,7 +136,7 @@ research!
 #### JavaScript Libraries
 
 * [bitsharesjs](https://github.com/bitshares/bitsharesjs) - used by reference wallet
-* [vuex-bitshares](https://github.com/TrustyFund/vuex-bitshares) - used by Trusty/Community UI
+* [vuex-bitshares](https://github.com/bitshares/vuex-bitshares) - used by Community UI web wallet
 
 #### Python Libraries
 


### PR DESCRIPTION
- Add Decentralized 2018 is slightly different formatting than contributing.md suggests.
- Update from trusty's github to bitshares github for bitshares-vuex (220 commits ahead)
- Rename of Trusty to just Community UI (there is no branding on it)
- updating description of Community UI
Few more minor tweaks/suggestions.